### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089
 
       - name: Setup node env
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
         with:
           node-version: ${{ matrix.node }}
           cache: yarn


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/lint.yaml:22` `actions/checkout@master` -> `actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089`
- `.github/workflows/lint.yaml:25` `actions/setup-node@v3` -> `actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610`