### PR TITLE
ci: pin vendored action references

### DIFF
--- a/packages/foundry/lib/openzeppelin-contracts/.github/actions/gas-compare/action.yml
+++ b/packages/foundry/lib/openzeppelin-contracts/.github/actions/gas-compare/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: bash
     - name: Save report
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
       with:
         name: gasreport
         path: ${{ inputs.out_report }}

--- a/packages/foundry/lib/openzeppelin-contracts/.github/actions/setup/action.yml
+++ b/packages/foundry/lib/openzeppelin-contracts/.github/actions/setup/action.yml
@@ -3,10 +3,10 @@ name: Setup
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610
       with:
         node-version: 16.x
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c
       id: cache
       with:
         path: '**/node_modules'
@@ -16,6 +16,6 @@ runs:
       shell: bash
       if: steps.cache.outputs.cache-hit != 'true'
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
       with:
         version: nightly

--- a/packages/foundry/lib/openzeppelin-contracts/.github/actions/storage-layout/action.yml
+++ b/packages/foundry/lib/openzeppelin-contracts/.github/actions/storage-layout/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
     - name: Save artifacts
       if: github.event_name != 'pull_request'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
       with:
         name: layout
         path: ${{ inputs.out_layout }}


### PR DESCRIPTION
## Summary

- Pin vendored OpenZeppelin action metadata references to immutable commit SHAs.
- Unblocks the org-wide external action SHA verifier before tightening GitHub Actions allowed-actions policy.

## Pinned refs

### packages/foundry/lib/openzeppelin-contracts/.github/actions/gas-compare/action.yml
- actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 already pinned

### packages/foundry/lib/openzeppelin-contracts/.github/actions/setup/action.yml
- actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 already pinned
- actions/cache@6f8efc29b200d32929f49075959781ed54ec270c already pinned
- foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d already pinned

### packages/foundry/lib/openzeppelin-contracts/.github/actions/storage-layout/action.yml
- actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 already pinned

## Test plan

- Org-wide deep action SHA pinning scan will be rerun after merge.